### PR TITLE
Fix rcmdcheck

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
         fi
-        Rscript ${GITHUB_ACTION_PATH}/rmindepscheck.R ${{ inputs.repository-path }} ${{ inputs.build-args }} ${{ inputs.check-args }}
+        Rscript ${GITHUB_ACTION_PATH}/script.R ${{ inputs.repository-path }} ${{ inputs.build-args }} ${{ inputs.check-args }}
       shell: bash
       env:
         GITHUB_PAT: "${{ inputs.github-token }}"

--- a/rmindepscheck.R
+++ b/rmindepscheck.R
@@ -1,9 +1,7 @@
-catnl <- function(x) cat(sprintf("%s\n", x))
-catbr <- function() catnl("---")
+catnl <- function(x = "") cat(sprintf("%s\n", x))
 
-catbr()
 catnl("Install required packages")
-install.packages("remotes")
+install.packages(c("remotes", "cli"))
 remotes::install_github("insightsengineering/verdepcheck")
 remotes::install_github("r-lib/rcmdcheck#196") # TODO: remove when merged / linked issue fixed
 
@@ -14,75 +12,58 @@ if (is.na(build_args) || build_args == "") build_args <- character(0)
 check_args <- strsplit(args[3], " ")[[1]]
 if (is.na(check_args) || check_args == "") check_args <- character(0)
 
-catbr()
-catnl("Cat script parameters")
+cli::cli_h1("Cat script parameters")
 catnl("path:")
 catnl(path)
-catnl("\n")
 catnl("build_args:")
 catnl(build_args)
-catnl("\n")
 catnl("check_args:")
 catnl(check_args)
-catnl("\n")
 
-catbr()
-catnl("Execute verdepcheck...")
+cli::cli_h1("Execute verdepcheck...")
 x <- verdepcheck::min_deps_check(path, check_args = check_args, build_args = build_args)
 
 
-catbr()
-catnl("Installation proposal:")
+cli::cli_h1("Installation proposal:")
 x$ip
 
-catbr()
-catnl("Package DESCRIPTION file used:")
+cli::cli_h2("Package DESCRIPTION file used:")
 catnl(readLines(gsub(".*::", "", x$ip$get_refs())))
 
-catbr()
-catnl("Dependency solution:")
+cli::cli_h2("Dependency solution:")
 x$ip$get_solution()
 
-catbr()
-catnl("Dependency resolution:")
-subset(x$ip$get_resolution(), , c(ref, package, version))
+cli::cli_h2("Dependency resolution:")
+print(subset(x$ip$get_resolution(), , c(ref, package, version)), n = Inf)
 
-catbr()
-catnl("Dependency resolution (tree):")
+cli::cli_h2("Dependency resolution (tree):")
 try(x$ip$draw())
 
-catbr()
-catnl("Create lockfile:")
+
+cli::cli_h1("Create lockfile...")
 try(x$ip$create_lockfile("pkg.lock"))
 
 
-catbr()
-catnl("R CMD CHECK:")
+cli::cli_h1("R CMD CHECK:")
 x$check
 
-catbr()
-catnl("R CMD CHECK status:")
+cli::cli_h2("R CMD CHECK status:")
 catnl(x$check$status)
 
-catbr()
-catnl("R CMD CHECK install out:")
+cli::cli_h2("R CMD CHECK install out:")
 cat(x$check$install_out)
 
-catbr()
-catnl("R CMD CHECK stdout:")
+cli::cli_h2("R CMD CHECK stdout:")
 cat(x$check$stdout)
 
-catbr()
-catnl("R CMD CHECK stderr:")
+cli::cli_h2("R CMD CHECK stderr:")
 cat(x$check$stderr)
 
-catbr()
-catnl("R CMD CHECK session info:")
+cli::cli_h2("R CMD CHECK session info:")
 x$check$session_info
 
-catbr()
-catnl("R CMD CHECK test output:")
+cli::cli_h2("R CMD CHECK test output:")
 lapply(x$check$test_output, cat)
 
-catbr()
+catnl()
 stopifnot("R CMD CHECK resulted in error - please see the above log for details" = x$check$status == 0)

--- a/rmindepscheck.R
+++ b/rmindepscheck.R
@@ -5,6 +5,7 @@ catbr()
 catnl("Install required packages")
 install.packages("remotes")
 remotes::install_github("insightsengineering/verdepcheck")
+remotes::install_github("r-lib/rcmdcheck@#196") # TODO: remove when merged / linked issue fixed
 
 args <- commandArgs(trailingOnly = TRUE)
 path <- normalizePath(file.path(".", args[1]))

--- a/rmindepscheck.R
+++ b/rmindepscheck.R
@@ -5,7 +5,7 @@ catbr()
 catnl("Install required packages")
 install.packages("remotes")
 remotes::install_github("insightsengineering/verdepcheck")
-remotes::install_github("r-lib/rcmdcheck@#196") # TODO: remove when merged / linked issue fixed
+remotes::install_github("r-lib/rcmdcheck#196") # TODO: remove when merged / linked issue fixed
 
 args <- commandArgs(trailingOnly = TRUE)
 path <- normalizePath(file.path(".", args[1]))
@@ -13,11 +13,6 @@ build_args <- strsplit(args[2], " ")[[1]]
 if (is.na(build_args) || build_args == "") build_args <- character(0)
 check_args <- strsplit(args[3], " ")[[1]]
 if (is.na(check_args) || check_args == "") check_args <- character(0)
-
-# @TODO: wait for https://github.com/r-lib/rcmdcheck/issues/195
-# as a workaround - skip vignettes
-check_args <- unique(c(check_args, "--ignore-vignettes"))
-build_args <- unique(c(build_args, "--no-build-vignettes"))
 
 catbr()
 catnl("Cat script parameters")

--- a/script.R
+++ b/script.R
@@ -27,7 +27,7 @@ x <- verdepcheck::min_deps_check(path, check_args = check_args, build_args = bui
 cli::cli_h1("Installation proposal:")
 x$ip
 
-cli::cli_h2("Package DESCRIPTION file used:")
+cli::cli_h2("Package DESCRIPTION file used (see Remotes section):")
 catnl(readLines(gsub(".*::", "", x$ip$get_refs())))
 
 cli::cli_h2("Dependency solution:")
@@ -38,6 +38,12 @@ print(subset(x$ip$get_resolution(), , c(ref, package, version)), n = Inf)
 
 cli::cli_h2("Dependency resolution (tree):")
 try(x$ip$draw())
+
+# TODO: https://github.com/r-lib/pkgdepends/issues/305 - remove when fixed
+cli::cli_h2("Supplementary solution (experimental - use only when the above results in empty report):")
+xx <- pkgdepends::new_pkg_deps(desc::desc(gsub("deps::", "", x$ip$get_refs()))$get_remotes(), config = list(library = tempfile()))
+xx$solve()
+xx$get_solution()
 
 
 cli::cli_h1("Create lockfile...")


### PR DESCRIPTION
- rename script to `script.R` to decouple from only min deps check
- use `cli` for better log output
- additional log entry in case of empty report (temporary until it got fixed)
- overinstall `rmcdcheck` package with bug-fixed branch (temporary until it got fixed)