### PR TITLE
Fix integration timeout

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
         echo "R_LIBS_SITE = $R_LIBS_SITE"
         echo "R_LIBS = $R_LIBS"
         fi
-        Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
+        Rscript --vanilla ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:
         GITHUB_PAT: "${{ inputs.github-token }}"

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,7 @@ runs:
         echo "R_LIBS_SITE = $R_LIBS_SITE"
         echo "R_LIBS = $R_LIBS"
         fi
+        rm /usr/local/lib/R/etc/Renviron
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -50,6 +50,7 @@ runs:
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
         fi
+        echo ".libPaths(\" \", include.site = FALSE)" > .Rprofile
         export R_LIBS_SITE=" "
         export R_LIBS_USER=" "
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
         echo "R_LIBS_SITE = $R_LIBS_SITE"
         echo "R_LIBS = $R_LIBS"
         fi
-        rm /usr/local/lib/R/etc/Renviron
+        sed -i 's/R_LIBS_SITE.*$//g' /usr/local/lib/R/etc/Renviron
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,8 @@ runs:
           echo -e "${{ inputs.additional-env-vars }}" > /tmp/dotenv.env
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
+        echo "R_LIBS_SITE = $R_LIBS_SITE"
+        echo "R_LIBS = $R_LIBS"
         fi
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -50,6 +50,7 @@ runs:
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
         fi
+        echo ".libPaths(\" \", include.site = FALSE)" > .Rprofile
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
         echo "R_LIBS_SITE = $R_LIBS_SITE"
         echo "R_LIBS = $R_LIBS"
         fi
-        Rscript --vanilla ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
+        Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:
         GITHUB_PAT: "${{ inputs.github-token }}"

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,6 @@ runs:
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
         fi
-        echo ".libPaths(\" \", include.site = FALSE)" > .Rprofile
         export R_LIBS_SITE=" "
         export R_LIBS_USER=" "
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'

--- a/action.yaml
+++ b/action.yaml
@@ -44,15 +44,12 @@ runs:
     - name: Run Dependency Test
       run: |
         echo "Dependency Test strategy: ${{ inputs.strategy }}"
-        if [ '${{ inputs.additional-env-vars }}' != "" ]
+        if [ "${{ inputs.additional-env-vars }}" != "" ]
         then {
           echo -e "${{ inputs.additional-env-vars }}" > /tmp/dotenv.env
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
-        echo "R_LIBS_SITE = $R_LIBS_SITE"
-        echo "R_LIBS = $R_LIBS"
         fi
-        sed -i 's/R_LIBS_SITE.*$//g' /usr/local/lib/R/etc/Renviron
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,8 @@ runs:
         }
         fi
         echo ".libPaths(\" \", include.site = FALSE)" > .Rprofile
+        export R_LIBS_SITE=" "
+        export R_LIBS_USER=" "
         Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.build-args }}' '${{ inputs.check-args }}' '${{ inputs.strategy }}'
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -44,7 +44,7 @@ runs:
     - name: Run Dependency Test
       run: |
         echo "Dependency Test strategy: ${{ inputs.strategy }}"
-        if [ "${{ inputs.additional-env-vars }}" != "" ]
+        if [ '${{ inputs.additional-env-vars }}' != "" ]
         then {
           echo -e "${{ inputs.additional-env-vars }}" > /tmp/dotenv.env
           export $(tr '\n' ' ' < /tmp/dotenv.env)

--- a/script.R
+++ b/script.R
@@ -1,5 +1,7 @@
 print(as.list(Sys.getenv()))
 print(.libPaths())
+.libPaths(" ", include.site = FALSE)
+print(.libPaths())
 print(rownames(installed.packages()))
 
 catnl <- function(x = "") cat(sprintf("%s\n", x))

--- a/script.R
+++ b/script.R
@@ -1,4 +1,4 @@
-Sys.getenv()
+print(as.list(Sys.getenv()))
 print(.libPaths())
 
 catnl <- function(x = "") cat(sprintf("%s\n", x))

--- a/script.R
+++ b/script.R
@@ -1,3 +1,5 @@
+print(.libPaths())
+
 catnl <- function(x = "") cat(sprintf("%s\n", x))
 
 catnl("Install required packages")

--- a/script.R
+++ b/script.R
@@ -39,8 +39,11 @@ x <- fun(path, check_args = check_args, build_args = build_args)
 
 cli::cli_h1("Debug output:")
 
-cli::cli_h1("Installation proposal:")
+cli::cli_h2("Installation proposal:")
 x$ip
+
+cli::cli_h2("Installation proposal config:")
+x$ip$get_config()
 
 cli::cli_h2("Package DESCRIPTION file used (see Remotes section):")
 catnl(readLines(gsub(".*::", "", x$ip$get_refs())))

--- a/script.R
+++ b/script.R
@@ -1,3 +1,4 @@
+Sys.getenv()
 print(.libPaths())
 
 catnl <- function(x = "") cat(sprintf("%s\n", x))

--- a/script.R
+++ b/script.R
@@ -1,5 +1,6 @@
 print(as.list(Sys.getenv()))
 print(.libPaths())
+print(rownames(installed.packages()))
 
 catnl <- function(x = "") cat(sprintf("%s\n", x))
 

--- a/script.R
+++ b/script.R
@@ -1,13 +1,9 @@
-print(as.list(Sys.getenv()))
-print(.libPaths())
-print(rownames(installed.packages()))
-
 catnl <- function(x = "") cat(sprintf("%s\n", x))
 
 catnl("Install required packages")
-install.packages(c("remotes", "cli"))
-remotes::install_github("insightsengineering/verdepcheck")
-remotes::install_github("r-lib/rcmdcheck#196") # TODO: remove when merged / linked issue fixed
+install.packages(c("remotes", "cli"), quiet = TRUE, verbose = FALSE)
+remotes::install_github("insightsengineering/verdepcheck", quiet = TRUE, verbose = FALSE)
+remotes::install_github("r-lib/rcmdcheck#196", quiet = TRUE, verbose = FALSE) # TODO: remove when merged / linked issue fixed
 
 args <- commandArgs(trailingOnly = TRUE)
 path <- normalizePath(file.path(".", args[1]))
@@ -50,7 +46,7 @@ cli::cli_h2("Dependency solution:")
 x$ip$get_solution()
 
 cli::cli_h2("Dependency resolution:")
-print(subset(x$ip$get_resolution(), , c(ref, package, version)), n = Inf)
+print(as.data.frame(subset(x$ip$get_resolution(), , c(ref, package, version))))
 
 cli::cli_h2("Dependency resolution (tree):")
 try(x$ip$draw())

--- a/script.R
+++ b/script.R
@@ -1,7 +1,5 @@
 print(as.list(Sys.getenv()))
 print(.libPaths())
-.libPaths(" ", include.site = FALSE)
-print(.libPaths())
 print(rownames(installed.packages()))
 
 catnl <- function(x = "") cat(sprintf("%s\n", x))


### PR DESCRIPTION
- remove `/usr/local/lib/R/site-library` from libpath to mimic _empty_ R installation - this is done with `.Rprofile` and envvars (hardcoded in the action)
- quiet and non-verbose package installation
- add installation proposal config print in the debug prints
- convert to `data.frame` and don't use `n = ...` option when printing in case `tibble` is not available to avoid `"invalid 'na.print' specification"` error
- run supplementary error report conditionally