### PR TITLE
Supports new strategies `min_isolated` and `min_cohort`

### DIFF
--- a/script.R
+++ b/script.R
@@ -11,7 +11,7 @@ catnl_param <- function(x = "") {
 catnl("Install required packages")
 
 install.packages(c("remotes", "cli"), quiet = TRUE, verbose = FALSE, repos = "http://cran.us.r-project.org")
-remotes::install_github("insightsengineering/verdepcheck@training-improvements", quiet = TRUE, verbose = FALSE)
+remotes::install_github("insightsengineering/verdepcheck", quiet = TRUE, verbose = FALSE)
 remotes::install_github("r-lib/rcmdcheck#196", quiet = TRUE, verbose = FALSE) # TODO: remove when merged / linked issue fixed
 
 

--- a/script.R
+++ b/script.R
@@ -14,7 +14,6 @@ install.packages(c("remotes", "cli"), quiet = TRUE, verbose = FALSE, repos = "ht
 remotes::install_github("insightsengineering/verdepcheck", quiet = TRUE, verbose = FALSE)
 remotes::install_github("r-lib/rcmdcheck#196", quiet = TRUE, verbose = FALSE) # TODO: remove when merged / linked issue fixed
 
-
 args <- commandArgs(trailingOnly = TRUE)
 path <- normalizePath(file.path(".", args[1]))
 build_args <- strsplit(args[2], " ")[[1]]

--- a/script.R
+++ b/script.R
@@ -5,7 +5,7 @@ catnl_param <- function(x = "") {
   var_name <- tryCatch(rlang::as_name(rlang::enexpr(x)), error = function(err) NULL)
   if (is.null(var_name)) return(catnl(x))
   var_string <- sprintf("%s:", var_name)
-  if(length(x) == 0) cat(var_string, "(empty)\n") else cat(var_string, x, "\n")
+  if (length(x) == 0) cat(var_string, "(empty)\n") else cat(var_string, x, "\n")
 }
 
 catnl("Install required packages")

--- a/script.R
+++ b/script.R
@@ -1,9 +1,19 @@
+# Print with a string with new line
 catnl <- function(x = "") cat(sprintf("%s\n", x))
+# Print a string from a variable (showing variable name before)
+catnl_param <- function(x = "") {
+  var_name <- tryCatch(rlang::as_name(rlang::enexpr(x)), error = function(err) NULL)
+  if (is.null(var_name)) return(catnl(x))
+  var_string <- sprintf("%s:", var_name)
+  if(length(x) == 0) cat(var_string, "(empty)\n") else cat(var_string, x, "\n")
+}
 
 catnl("Install required packages")
+
 install.packages(c("remotes", "cli"), quiet = TRUE, verbose = FALSE, repos = "http://cran.us.r-project.org")
-remotes::install_github("insightsengineering/verdepcheck", quiet = TRUE, verbose = FALSE)
+remotes::install_github("insightsengineering/verdepcheck@training-improvements", quiet = TRUE, verbose = FALSE)
 remotes::install_github("r-lib/rcmdcheck#196", quiet = TRUE, verbose = FALSE) # TODO: remove when merged / linked issue fixed
+
 
 args <- commandArgs(trailingOnly = TRUE)
 path <- normalizePath(file.path(".", args[1]))
@@ -12,19 +22,16 @@ check_args <- strsplit(args[3], " ")[[1]]
 strategy <- strsplit(args[4], " ")[[1]]
 
 cli::cli_h1("Cat script parameters")
-catnl("path:")
-catnl(path)
-catnl("build_args:")
-catnl(build_args)
-catnl("check_args:")
-catnl(check_args)
-catnl("strategy:")
-catnl(strategy)
+catnl_param(path)
+catnl_param(build_args)
+catnl_param(check_args)
+catnl_param(strategy)
 
 cli::cli_h1("Execute verdepcheck...")
 fun <- switch(
     strategy,
-    "min" = verdepcheck::min_deps_check,
+    "min_cohort" = verdepcheck::min_cohort_deps_check,
+    "min_isolated" = verdepcheck::min_isolated_deps_check,
     "release" = verdepcheck::release_deps_check,
     "max" = verdepcheck::max_deps_check,
     stop("Unknown strategy")


### PR DESCRIPTION
WIP :: parent issue: https://github.com/insightsengineering/nestdevs-tasks/issues/7

### 🔴 What's needed before merging?

#### Changes in code

- [x] Change branch of [insightsengineering/verdepcheck](https://github.com/insightsengineering/verdepcheck/) from `@training-improvements` to `@main`


#### PR

- [ ] verdepcheck
  * https://github.com/insightsengineering/verdepcheck/pull/26
  * https://github.com/insightsengineering/verdepcheck/pull/24


### Changes description

* Replaces call to `min` strategy with `min_isolated` and `min_cohorts`
* Small change on how to show the parameters